### PR TITLE
Update the server connector extension ID

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Server Connector extension ID.
  */
-export const SERVER_CONNECTOR_EXTENSION_ID = 'redhat.vscode-server-connector';
+export const SERVER_CONNECTOR_EXTENSION_ID = 'redhat.vscode-rsp-ui';
 
 /**
  * Constants representing the state of the server itself or the state of publishing to the server

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -12,8 +12,3 @@ export interface RSPServer {
     type: RSPType;
     state: number;
 }
-
-export interface ServerInfo {
-    host: string;
-    port: number;
-}


### PR DESCRIPTION
since 'redhat.vscode-rsp-ui' now replaces the server-connector as the UI part