### PR TITLE
script test definition should return 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "rimraf lib && tslint -p tslint.json && tsc",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"No tests have been provided yet\"",
     "coverage:upload": "codecov -f coverage/*.json"
   },
   "nyc": {


### PR DESCRIPTION
Seems like travis-ci runs in nodejs project npm test by default.

Signed-off-by: Ondrej Dockal <odockal@redhat.com>